### PR TITLE
Handle local roles after checkout/checkin

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,9 @@ Changelog
 2.1.13 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Handle local roles when checkout and checkin.
+  Credits goes to http://plone.org/products/iterate/issues/28
+  [jfroche]
 
 
 2.1.12 (2014-02-19)

--- a/plone/app/iterate/copier.py
+++ b/plone/app/iterate/copier.py
@@ -150,6 +150,9 @@ class ContentCopier( object ):
                 continue
             wf.updateRoleMappingsFor( new_baseline )
 
+        if hasattr(baseline, '__ac_local_roles__'):
+            new_baseline.__ac_local_roles__ = dict(baseline.__ac_local_roles__)
+
         # Reattach the source's uid, this will update wc refs to point
         # back to the new baseline.  This may introduce duplicate
         # references, so we check that and fix them.

--- a/plone/app/iterate/tests/test_iterate.py
+++ b/plone/app/iterate/tests/test_iterate.py
@@ -94,6 +94,18 @@ class TestIterations(PloneTestCase.PloneTestCase):
         self.assertEqual( state, bstate )
         self.setRoles(['Owner',])
 
+    def test_localroles(self):
+        doc = self.portal.docs.doc1
+        doc.manage_addLocalRoles('user1', ['Editor'])
+        self.assertEqual(doc.__ac_local_roles__,
+                         {'test_user_1_': ['Owner'], 'user1': ['Editor']})
+        self.repo.save(doc)
+
+        wc = ICheckinCheckoutPolicy(doc).checkout(self.portal.workarea)
+        ICheckinCheckoutPolicy(wc).checkin( "modified" )
+        self.assertEqual(wc.__ac_local_roles__,
+                         {'test_user_1_': ['Owner'], 'user1': ['Editor']})
+
     def test_baselineVersionCreated( self ):
         # if a baseline has no version ensure that one is created on checkout
 


### PR DESCRIPTION
issue initially created here with a good fix: http://plone.org/products/iterate/issues/28

Local roles assigned on an object (for example through sharing tab) will be kept after a checkout and checkin.