### PR TITLE
13881 prevent ownership change

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,11 @@ Changelog
 2.1.13 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Apply the original content object's local roles when replacing it with
+  a checked-in working copy. Prevents users from obtaining owner rights
+  to content through the check out/check in process.
+  Closes https://dev.plone.org/ticket/13881
+  [esteele]
 
 2.1.12 (2014-02-19)
 -------------------

--- a/plone/app/iterate/copier.py
+++ b/plone/app/iterate/copier.py
@@ -96,6 +96,9 @@ class ContentCopier( object ):
         # new baseline
         baseline_id = baseline.getId()
 
+        # Get the list of locally assigned roles on the baseline item
+        baseline_local_roles = baseline.get_local_roles()
+
         # delete the baseline from the folder to make room for the
         # committed working copy
         baseline_container = aq_parent( aq_inner( baseline ) )
@@ -123,6 +126,16 @@ class ContentCopier( object ):
         baseline_container.moveObjectToPosition(baseline_id, baseline_pos)
 
         new_baseline = baseline_container._getOb( baseline_id )
+
+        # Apply the local roles from the original baseline to the new one.
+        # First remove any existing roles
+        roles_to_remove = new_baseline.get_local_roles()
+        for username, roles in roles_to_remove:
+            new_baseline.manage_delLocalRoles([username])
+        # Now apply the original ones.
+        for username, roles in baseline_local_roles:
+            new_baseline.manage_setLocalRoles(username, roles)
+
 
         # reregister our references with the reference machinery after moving
         Referenceable.manage_afterAdd( new_baseline, new_baseline,

--- a/plone/app/iterate/tests/browser.txt
+++ b/plone/app/iterate/tests/browser.txt
@@ -129,6 +129,13 @@ again and check in (and then possibly request for review):
   >>> "Checked in" in browser.contents
   True
 
+Ensure the editor has not gained owner rights to the content
+(See https://dev.plone.org/ticket/13881)
+
+  >>> portal['hello-world'].get_local_roles()
+  (('portal_owner', ('Owner',)),)
+
+
 Folders
 -------
 


### PR DESCRIPTION
#### What does this pull request do?

When a checked-out item was checked back in, ownership of the item was transferred from the original creator to the user who made the change. Proposed change copies local roles from the original content object and applies them to the new copy replacing it. 

#### How should this be manually tested?

User1 adds a page. User2 checks out the page, makes a change and submits for publication. User1 checks in the changed copy. Checking local roles for the page, User1 should be listed as having the Owner role, User2 should not.

#### What are the relevant tickets?

https://dev.plone.org/ticket/13881