### PR TITLE
Check if object does not have iterate policy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 3.1.1 (unreleased)
 ------------------
 
-- Handle checking if object does not have iterate policy
+- Check if object does not have iterate policy. This fixes
+  iterate causing toolbar errors on portal root.
   [vangheem]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 3.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Handle checking if object does not have iterate policy
+  [vangheem]
 
 
 3.1.0 (2015-07-18)

--- a/plone/app/iterate/browser/control.py
+++ b/plone/app/iterate/browser/control.py
@@ -52,7 +52,10 @@ class Control(BrowserView):
         if not IWorkingCopy.providedBy(context):
             return False
 
-        policy = ICheckinCheckoutPolicy(context)
+        policy = ICheckinCheckoutPolicy(context, None)
+        if policy is None:
+            return False
+
         original = policy.getBaseline()
         if original is None:
             return False
@@ -74,7 +77,9 @@ class Control(BrowserView):
         if not archiver.isVersionable():
             return False
 
-        policy = ICheckinCheckoutPolicy(context)
+        policy = ICheckinCheckoutPolicy(context, None)
+        if policy is None:
+            return False
 
         if policy.getWorkingCopy() is not None:
             return False
@@ -90,6 +95,8 @@ class Control(BrowserView):
         """Check to see if the user can cancel the checkout on the
         given working copy
         """
-        policy = ICheckinCheckoutPolicy(self.context)
+        policy = ICheckinCheckoutPolicy(self.context, None)
+        if policy is None:
+            return False
         original = policy.getBaseline()
         return original is not None

--- a/plone/app/iterate/tests/test_iterate.py
+++ b/plone/app/iterate/tests/test_iterate.py
@@ -24,18 +24,16 @@ $Id: test_iterate.py 1595 2006-08-24 00:15:21Z hazmat $
 """
 
 from AccessControl import getSecurityManager
-
 from Products.CMFCore.utils import getToolByName
-
+from plone.app.iterate.browser.control import Control
 from plone.app.iterate.interfaces import ICheckinCheckoutPolicy
 from plone.app.iterate.testing import PLONEAPPITERATE_INTEGRATION_TESTING
-
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import login
 from plone.app.testing import setRoles
-
 import unittest2 as unittest
+
 
 class TestIterations(unittest.TestCase):
 
@@ -277,3 +275,15 @@ class TestIterations(unittest.TestCase):
 
         # everything went right and the working copy is checked in
         self.assertEqual(subobject_uid, wc.UID())
+
+    def test_control_checkin_allowed_with_no_policy(self):
+        control = Control(self.portal, self.layer['request'])
+        self.assertFalse(control.checkin_allowed())
+
+    def test_control_checkout_allowed_with_no_policy(self):
+        control = Control(self.portal, self.layer['request'])
+        self.assertFalse(control.checkout_allowed())
+
+    def test_control_cancel_allowed_with_no_policy(self):
+        control = Control(self.portal, self.layer['request'])
+        self.assertFalse(control.cancel_allowed())


### PR DESCRIPTION
This fixes iterate causing toolbar errors on portal root.