### PR TITLE
Keep default page on checkin (Plone 4.3)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,10 @@ Changelog
 2.1.14 (unreleased)
 -------------------
 
-- Nothing changed yet.
+Fixes:
+
+- Keep the default page setting when checking in a document.
+  [maurits]
 
 
 2.1.13 (2014-04-16)

--- a/plone/app/iterate/copier.py
+++ b/plone/app/iterate/copier.py
@@ -99,6 +99,10 @@ class ContentCopier( object ):
         # delete the baseline from the folder to make room for the
         # committed working copy
         baseline_container = aq_parent( aq_inner( baseline ) )
+        # Check if we are a default_page, because this property of the
+        # container might get lost.
+        is_default_page = (
+            baseline_container.getProperty('default_page', '') == baseline_id)
         baseline_pos = baseline_container.getObjectPosition(baseline_id)
         baseline_container._delOb( baseline_id )
 
@@ -123,6 +127,13 @@ class ContentCopier( object ):
         baseline_container.moveObjectToPosition(baseline_id, baseline_pos)
 
         new_baseline = baseline_container._getOb( baseline_id )
+        if is_default_page:
+            # Restore default_page to container.  Note that the property might
+            # have been removed by an event handler in the mean time.
+            if baseline_container.hasProperty('default_page'):
+                baseline_container._updateProperty('default_page', baseline_id)
+            else:
+                baseline_container._setProperty('default_page', baseline_id)
 
         # reregister our references with the reference machinery after moving
         Referenceable.manage_afterAdd( new_baseline, new_baseline,

--- a/plone/app/iterate/tests/test_iterate.py
+++ b/plone/app/iterate/tests/test_iterate.py
@@ -271,6 +271,24 @@ class TestIterations(PloneTestCase.PloneTestCase):
         # everything went right and the working copy is checked in
         self.assertEqual(subobject_uid, wc.UID())
 
+    def test_default_page_is_kept_in_folder(self):
+        # Ensure that a default page that is checked out and back in is still
+        # the default page.
+        folder = self.portal.docs
+        doc = folder.doc1
+        from Products.CMFDynamicViewFTI.interfaces import \
+            ISelectableBrowserDefault
+        ISelectableBrowserDefault(folder).setDefaultPage('doc1')
+        self.assertEqual(folder.getProperty('default_page', ''), 'doc1')
+        self.assertEqual(folder.getDefaultPage(), 'doc1')
+        # Note: when checking out to self.portal.workarea it surprisingly works
+        # without changes.  But the default behavior in Plone is to check a
+        # document out in its original folder, so that is what we check here.
+        wc = ICheckinCheckoutPolicy(doc).checkout(folder)
+        doc = ICheckinCheckoutPolicy(wc).checkin("updated")
+        self.assertEqual(folder.getProperty('default_page', ''), 'doc1')
+        self.assertEqual(folder.getDefaultPage(), 'doc1')
+
 
 class IterateFunctionalTestCase(PloneTestCase.FunctionalTestCase):
     pass


### PR DESCRIPTION
This pull request in CMFDynamicViewFTI introduced event handlers that clean up the default_page property when deleting a page:ttps://github.com/plone/Products.CMFDynamicViewFTI/pull/4
Good.
Then this fix came along, which made it function better (not only in tests but for real I think):
https://github.com/plone/Products.CMFDynamicViewFTI/commit/6ecdf22593f13ac0bc5bf546b5ce92e2bfa7a6e8
Very good.

But now the following scenario in plone.app.iterate 'breaks'.
- Activate plone.app.iterate.
- Create a folder.
- Create a page.
- Make this page the default_page of the folder.
- Check out the page.
- Check in the page.
Bug: the default_page property is gone: the folder shows the standard folder listing.
This works fine with Plone 4.3.5 and fails in Plone 4.3.6 (and 4.3.7 and current coredev).

The problem is that in the checkin phase this happens:
1. plone.app.iterate removes the original page
2. In CMFDynamicViewFTI the `check_default_page` event handler is triggered and removes the default_page property.
3. plone.app.iterate adds the updated page.

This pull requests saves the default_page property and restores it if needed.