### PR TITLE
Cleanup + Added profile id "default" and deprecated id "plone.app.iterate".

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,10 +8,26 @@ New:
 
 - *add item here*
 
+- plone.app.iterate depends on GenericSetup >= 1.8.2
+  for using a post_handler on registerProfile
+  [iham]
+
+- Added naming of default GenericSetup profile as "default".
+  "plone.app.iterate" also exists to keep compatibility.
+  [iham]
+
+- Added deprecation warning to GS profile "plone.app.iterate"
+  [iham]
+
 Fixes:
 
 - *add item here*
 
+- No need to register as Zope2 Product anymore.
+  [iham]
+
+- Some minor pep8 cleanup.
+  [iham]
 
 3.1.4 (2015-11-16)
 ------------------

--- a/plone/app/iterate/configure.zcml
+++ b/plone/app/iterate/configure.zcml
@@ -5,79 +5,92 @@
     xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="plone">
 
-    <include package="zope.annotation" />
-    <include package="Products.CMFCore" file="permissions.zcml" />
+  <include package="zope.annotation" />
+  <include package="Products.CMFCore" file="permissions.zcml" />
 
-    <include package=".subscribers"/>
-    <include package=".browser"/>
+  <include package=".subscribers"/>
+  <include package=".browser"/>
 
-    <!-- Set up as a Zope product and register an extension profile -->
-    <five:registerPackage package="." />
+  <includeDependencies package="." />
 
-    <genericsetup:registerProfile
-      name="plone.app.iterate"
-      title="Working Copy Support (Iterate)"
-      directory="profiles/default"
-      description="Adds working copy support (aka. in-place staging) to Plone."
+  <genericsetup:registerProfile
+    name="default"
+    title="Working Copy Support (Iterate)"
+    directory="profiles/default"
+    description="Adds working copy support (aka. in-place staging) to Plone."
+    provides="Products.GenericSetup.interfaces.EXTENSION"
+    />
+
+  <!--
+    Remove, when CMFPlone no more depends on this profile.
+    Products.CMFPlone/Products/CMFPlone/MigrationTool.py:99:
+    Addon(profile_id=u'plone.app.iterate:plone.app.iterate')
+  -->
+  <genericsetup:registerProfile
+    name="plone.app.iterate"
+    title="Working Copy Support (Iterate)"
+    directory="profiles/default"
+    description="Adds working copy support (aka. in-place staging) to Plone."
+    provides="Products.GenericSetup.interfaces.EXTENSION"
+    post_handler=".setuphandlers.deprecate_profile"
+    />
+
+  <genericsetup:registerProfile
+      name="test"
+      title="plone.app.iterate: Test fixture"
+      directory="profiles/test"
+      description="Extension profile to configure a test fixture"
+      for="Products.CMFPlone.interfaces.ITestCasePloneSiteRoot"
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 
-    <genericsetup:registerProfile
-        name="test"
-        title="plone.app.iterate: Test fixture"
-        directory="profiles/test"
-        description="Extension profile to configure a test fixture"
-        for="Products.CMFPlone.interfaces.ITestCasePloneSiteRoot"
-        provides="Products.GenericSetup.interfaces.EXTENSION"
-        />
-
-    <genericsetup:upgradeStep
-        source="*"
-        destination="121"
-        title="Reinstall plone.app.iterate"
-        description=""
-        profile="plone.app.iterate:plone.app.iterate"
-        handler="plone.app.iterate.util.upgrade_by_reinstall"
-        />
-
-    <!-- Policy and behaviour for basic objects -->
-    <class class="Products.Archetypes.BaseObject.BaseObject">
-        <implements interface=".interfaces.IIterateAware" />
-    </class>
-
-    <adapter factory=".policy.CheckinCheckoutPolicyAdapter" />
-    <adapter factory=".relation.CheckinCheckoutReferenceAdapter"/>
-    <adapter factory=".archiver.ContentArchiver" />
-    <adapter factory=".copier.ContentCopier" />
-
-    <!-- Checkout folder locators -->
-    <adapter
-        factory=".containers.HomeFolderLocator"
-        name="plone.app.iterate.home"
-        />
-
-    <adapter
-        factory=".containers.ParentFolderLocator"
-        name="plone.app.iterate.parent"
-        />
-
-    <!-- Handle deletions of working copies -->
-    <subscriber
-       for=".interfaces.IWorkingCopyRelation
-            zope.lifecycleevent.interfaces.IObjectRemovedEvent"
-       handler=".event.handleDeletion"
-       />
-
-    <permission
-      id="plone.app.iterate.CheckInContent"
-      title="iterate : Check in content"
+  <genericsetup:upgradeStep
+      source="*"
+      destination="121"
+      title="Reinstall plone.app.iterate"
+      description=""
+      profile="plone.app.iterate:plone.app.iterate"
+      handler="plone.app.iterate.util.upgrade_by_reinstall"
       />
 
-    <permission
-      id="plone.app.iterate.CheckOutContent"
-      title="iterate : Check out content"
+  <!-- Policy and behavior for basic objects -->
+  <class class="Products.Archetypes.BaseObject.BaseObject">
+      <implements interface=".interfaces.IIterateAware" />
+  </class>
+
+  <adapter factory=".policy.CheckinCheckoutPolicyAdapter" />
+  <adapter factory=".relation.CheckinCheckoutReferenceAdapter"/>
+  <adapter factory=".archiver.ContentArchiver" />
+  <adapter factory=".copier.ContentCopier" />
+
+  <!-- Checkout folder locators -->
+  <adapter
+      factory=".containers.HomeFolderLocator"
+      name="plone.app.iterate.home"
       />
 
-      <include package=".dexterity" zcml:condition="installed plone.app.relationfield" />
+  <adapter
+      factory=".containers.ParentFolderLocator"
+      name="plone.app.iterate.parent"
+      />
+
+  <!-- Handle deletions of working copies -->
+  <subscriber
+     for=".interfaces.IWorkingCopyRelation
+          zope.lifecycleevent.interfaces.IObjectRemovedEvent"
+     handler=".event.handleDeletion"
+     />
+
+  <permission
+    id="plone.app.iterate.CheckInContent"
+    title="iterate : Check in content"
+    />
+
+  <permission
+    id="plone.app.iterate.CheckOutContent"
+    title="iterate : Check out content"
+    />
+
+  <include package=".dexterity" zcml:condition="installed plone.app.relationfield" />
 
 </configure>

--- a/plone/app/iterate/setuphandlers.py
+++ b/plone/app/iterate/setuphandlers.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+"""Deprecation warning for plone.app.iterate:plone.app.iterate profile."""
+
+import warnings
+
+
+def deprecate_profile(tool):
+    """Deprecation profile plone.app.iterate."""
+    warnings.warn(
+        'The profile with id "plone.app.iterate" was renamed to "default".',
+        DeprecationWarning
+        )

--- a/plone/app/iterate/testing.py
+++ b/plone/app/iterate/testing.py
@@ -1,3 +1,4 @@
+"""Testing setup for integration and functional tests."""
 # -*- coding: utf-8 -*-
 from plone.app.contenttypes.testing import PloneAppContenttypes
 from plone.app.testing import PLONE_FIXTURE
@@ -8,37 +9,39 @@ from plone.app.testing.layers import IntegrationTesting
 from plone.testing import z2
 
 
-admin = {
+ADMIN = {
     'id': 'admin',
     'password': 'secret',
     'roles': ['Manager'],
 }
-editor = {
+EDITOR = {
     'id': 'editor',
     'password': 'secret',
     'roles': ['Editor'],
 }
-contributor = {
+CONTRIBUTOR = {
     'id': 'contributor',
     'password': 'secret',
     'roles': ['Contributor'],
 }
-users_to_be_added = (
-    admin,
-    editor,
-    contributor,
+USERS_TO_BE_ADDED = (
+    ADMIN,
+    EDITOR,
+    CONTRIBUTOR,
 )
-users_with_member_folder = (
-    editor,
-    contributor,
+USERS_WITH_MEMBER_FOLDER = (
+    EDITOR,
+    CONTRIBUTOR,
 )
 
 
 class PloneAppIterateLayer(PloneSandboxLayer):
+    """Plone Sandbox Layer for plone.app.iterate."""
 
     defaultBases = (PLONE_FIXTURE,)
 
     def setUpZope(self, app, configurationContext):
+        """Setup Zope with Addons."""
         import Products.ATContentTypes
         self.loadZCML(package=Products.ATContentTypes)
         z2.installProduct(app, 'Products.ATContentTypes')
@@ -50,19 +53,19 @@ class PloneAppIterateLayer(PloneSandboxLayer):
 
         import plone.app.iterate
         self.loadZCML(package=plone.app.iterate)
-        z2.installProduct(app, 'plone.app.iterate')
 
     def setUpPloneSite(self, portal):
+        """Setup Plone Site with Addons."""
         # restore default workflow
         applyProfile(portal, 'Products.CMFPlone:testfixture')
 
         # add default content
         applyProfile(portal, 'Products.ATContentTypes:content')
 
-        applyProfile(portal, 'plone.app.iterate:plone.app.iterate')
+        applyProfile(portal, 'plone.app.iterate:default')
         applyProfile(portal, 'plone.app.iterate:test')
 
-        for user in users_to_be_added:
+        for user in USERS_TO_BE_ADDED:
             portal.portal_membership.addMember(
                 user['id'],
                 user['password'],
@@ -70,7 +73,7 @@ class PloneAppIterateLayer(PloneSandboxLayer):
                 [],
             )
 
-        for user in users_with_member_folder:
+        for user in USERS_WITH_MEMBER_FOLDER:
             mtool = portal.portal_membership
             if not mtool.getMemberareaCreationFlag():
                 mtool.setMemberareaCreationFlag()
@@ -111,15 +114,20 @@ PLONEAPPITERATE_FUNCTIONAL_TESTING = FunctionalTesting(
 
 
 class DexPloneAppIterateLayer(PloneAppContenttypes):
+    """Dexterity based Plone Sandbox Layer for plone.app.iterate."""
+
     def setUpZope(self, app, configurationContext):
-        super(DexPloneAppIterateLayer, self).setUpZope(app, configurationContext)
+        """Setup Zope with Addons."""
+        super(DexPloneAppIterateLayer,
+              self).setUpZope(app, configurationContext)
+
         import plone.app.iterate
         self.loadZCML(package=plone.app.iterate)
-        z2.installProduct(app, 'plone.app.iterate')
 
     def setUpPloneSite(self, portal):
+        """Setup Plone Site with Addons."""
         super(DexPloneAppIterateLayer, self).setUpPloneSite(portal)
-        applyProfile(portal, 'plone.app.iterate:plone.app.iterate')
+        applyProfile(portal, 'plone.app.iterate:default')
 
 
 PLONEAPPITERATEDEX_FIXTURE = DexPloneAppIterateLayer()

--- a/setup.py
+++ b/setup.py
@@ -1,61 +1,70 @@
+"""Setup plone.app.iterate."""
 from setuptools import setup, find_packages
 
-version = '3.1.5.dev0'
+VERSION = '3.1.5.dev0'
 
-setup(name='plone.app.iterate',
-      version=version,
-      description="check-out/check-in staging for Plone",
-      long_description=open("README.rst").read() + "\n" + open("CHANGES.rst").read(),
-      classifiers=[
-          "Environment :: Web Environment",
-          "Framework :: Plone",
-          "Framework :: Plone :: 5.0",
-          "Framework :: Zope2",
-          "License :: OSI Approved :: GNU General Public License (GPL)",
-          "Operating System :: OS Independent",
-          "Programming Language :: Python",
-          "Programming Language :: Python :: 2.7",
-      ],
-      keywords='check-out check-in staging',
-      author='Plone Foundation',
-      author_email='plone-developers@lists.sourceforge.net',
-      url='https://pypi.python.org/pypi/plone.app.iterate',
-      license='GPL version 2',
-      packages=find_packages(exclude=['ez_setup']),
-      namespace_packages=['plone', 'plone.app'],
-      include_package_data=True,
-      zip_safe=False,
-      extras_require=dict(
-          test=[
-              'plone.app.testing',
-              'plone.app.contenttypes'
-          ]
-      ),
-      install_requires=[
-          'setuptools',
-          'plone.locking',
-          'plone.memoize',
-          'zope.annotation',
-          'zope.component',
-          'zope.event',
-          'zope.i18nmessageid',
-          'zope.interface',
-          'zope.lifecycleevent',
-          'zope.schema',
-          'zope.viewlet',
-          'Acquisition',
-          'DateTime',
-          'Products.Archetypes',
-          'Products.CMFCore',
-          'Products.CMFEditions',
-          'Products.CMFPlacefulWorkflow',
-          'Products.DCWorkflow',
-          'Products.statusmessages',
-          'ZODB3',
-          'Zope2',
-      ],
-      entry_points='''
-          [z3c.autoinclude.plugin]
-          target = plone
-      ''',
-      )
+LONG_DESCRIPTION = (
+    open('README.rst').read() +
+    '\n' +
+    open('CHANGES.rst').read() +
+    '\n')
+
+setup(
+    name='plone.app.iterate',
+    version=VERSION,
+    description="check-out/check-in staging for Plone",
+    long_description=LONG_DESCRIPTION,
+    classifiers=[
+        "Environment :: Web Environment",
+        "Framework :: Plone",
+        "Framework :: Plone :: 5.0",
+        "Framework :: Zope2",
+        "License :: OSI Approved :: GNU General Public License (GPL)",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+    ],
+    keywords='check-out check-in staging',
+    author='Plone Foundation',
+    author_email='plone-developers@lists.sourceforge.net',
+    url='https://pypi.python.org/pypi/plone.app.iterate',
+    license='GPL version 2',
+    packages=find_packages(exclude=['ez_setup']),
+    namespace_packages=['plone', 'plone.app'],
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=[
+        'setuptools',
+        'Products.GenericSetup>=1.8.2',
+        'plone.locking',
+        'plone.memoize',
+        'zope.annotation',
+        'zope.component',
+        'zope.event',
+        'zope.i18nmessageid',
+        'zope.interface',
+        'zope.lifecycleevent',
+        'zope.schema',
+        'zope.viewlet',
+        'Acquisition',
+        'DateTime',
+        'Products.Archetypes',
+        'Products.CMFCore',
+        'Products.CMFEditions',
+        'Products.CMFPlacefulWorkflow',
+        'Products.DCWorkflow',
+        'Products.statusmessages',
+        'ZODB3',
+        'Zope2',
+    ],
+    extras_require={
+        'test': [
+            'plone.app.testing',
+            'plone.app.contenttypes'
+        ]
+    },
+    entry_points="""
+    [z3c.autoinclude.plugin]
+    target = plone
+    """,
+)


### PR DESCRIPTION
plone.app.iterate is a confusing naming for a default GenericSetup profile id as the convention is to name it "default". Having to type `profile-plone.app.iterate:plone.app.iterate` makes it even worse when using it.

I - by the big help of @jensens and @thet - deprecated this profile by using the new post_handler in GS 1.8.2 and added the normal default profile and updated the tests.

The only known place where `profile-plone.app.iterate:plone.app.iterate` is called:
https://github.com/plone/Products.CMFPlone/blob/master/Products/CMFPlone/MigrationTool.py#L99