### PR TITLE
Issue 1451 - Setted lock timeout to MAX_TIMEOUT to avoid baseline unwanted unlock after 10 minutes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,7 +10,8 @@ New:
 
 Fixes:
 
-- *add item here*
+- Setted lock timeout to MAX_TIMEOUT to avoid baseline unwanted unlock after 10 minutes (closes `#1451`_).
+  [parruc, rodfersou]
 
 
 2.1.14 (2015-11-16)
@@ -328,3 +329,5 @@ Fixes:
 ----------------
 
 - First release
+
+.. _`#1451`: https://github.com/plone/Products.CMFPlone/issues/1451

--- a/plone/app/iterate/interfaces.py
+++ b/plone/app/iterate/interfaces.py
@@ -28,6 +28,7 @@ from zope import schema
 
 from zope.component.interfaces import IObjectEvent
 from plone.locking.interfaces import LockType
+from plone.locking.interfaces import MAX_TIMEOUT
 
 from Products.Archetypes.interfaces import IReference
 
@@ -41,7 +42,7 @@ class IIterateAware( Interface ):
 #################################
 ## Lock types
 
-ITERATE_LOCK = LockType( u'iterate.lock', stealable=False, user_unlockable=False )
+ITERATE_LOCK = LockType( u'iterate.lock', stealable=False, user_unlockable=False, timeout=MAX_TIMEOUT)
 
 #################################
 ## Exceptions


### PR DESCRIPTION
closes https://github.com/plone/Products.CMFPlone/issues/1451