### PR TITLE
Remove broken references when making checkout.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Remove broken references when making checkout.
+  Fixes issue `30 <https://github.com/plone/plone.app.iterate/issues/30>`_.
+  [maurits]
 
 
 2.1.17 (2016-05-10)


### PR DESCRIPTION
Fixes issue https://github.com/plone/plone.app.iterate/issues/30.

This is for branch 2.1.x, Plone 4.3.
I intend to do the same for master, Plone 5.
But let's first see if I can get an okay on 4.3.