### PR TITLE
Products.CMFPlacefulWorkflow requires workflow policy id to be byteststring

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Change ``IIterateSettings.checkout_workflow_policy`` to ASCIILine,
+  as required by ``Products.CMFWorkflowPolicy``.
 
 
 3.3.1 (2017-02-12)

--- a/plone/app/iterate/interfaces.py
+++ b/plone/app/iterate/interfaces.py
@@ -321,7 +321,7 @@ class IIterateSettings(Interface):
         required=False
     )
 
-    checkout_workflow_policy = schema.TextLine(
+    checkout_workflow_policy = schema.ASCIILine(
         title=_(u'Checkout workflow policy'),
         description=u'',
         default=u'checkout_workflow_policy',

--- a/plone/app/iterate/interfaces.py
+++ b/plone/app/iterate/interfaces.py
@@ -324,6 +324,6 @@ class IIterateSettings(Interface):
     checkout_workflow_policy = schema.ASCIILine(
         title=_(u'Checkout workflow policy'),
         description=u'',
-        default=u'checkout_workflow_policy',
+        default='checkout_workflow_policy',
         required=True
     )

--- a/plone/app/iterate/subscribers/workflow.py
+++ b/plone/app/iterate/subscribers/workflow.py
@@ -47,7 +47,7 @@ def handleCheckout(event):
     settings = registry.forInterface(IIterateSettings)
     if not settings.enable_checkout_workflow:
         return
-    policy_id = settings.checkout_workflow_policy
+    policy_id = str(settings.checkout_workflow_policy)
 
     existing_policy = getattr(
         aq_base(event.working_copy), WorkflowPolicyConfig_id, None)


### PR DESCRIPTION
The PR fixes the usecase when we want to use the placeful workflow policy (to have a different workflow for the checkouts)