### PR TITLE
Prevent using queryUtility with name=None

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Bug fixes:
 - removed "change portal events" permission
   [kakshay21]
 
+- Prevent using queryUtility with name=None
+  [pbauer]
 
 3.3.2 (2017-03-23)
 ------------------

--- a/plone/app/iterate/copier.py
+++ b/plone/app/iterate/copier.py
@@ -239,9 +239,14 @@ class ContentCopier(object):
 
         # handle forward references
         for relationship in baseline.getRelationships():
-            # look for a named relation adapter first
-            adapter = component.queryAdapter(
-                baseline, interfaces.ICheckinCheckoutReference, relationship)
+            if relationship is None:
+                adapter = None
+            else:
+                # look for a named relation adapter first
+                adapter = component.queryAdapter(
+                    baseline,
+                    interfaces.ICheckinCheckoutReference,
+                    relationship)
 
             if adapter is None:  # default
                 adapter = baseline_adapter
@@ -255,8 +260,15 @@ class ContentCopier(object):
 
         # handle backward references
         for relationship in baseline.getBRelationships():
-            adapter = component.queryAdapter(
-                baseline, interfaces.ICheckinCheckoutReference, relationship)
+            if relationship is None:
+                adapter = None
+            else:
+                # look for a named relation adapter first
+                adapter = component.queryAdapter(
+                    baseline,
+                    interfaces.ICheckinCheckoutReference,
+                    relationship)
+
             if adapter is None:
                 adapter = baseline_adapter
 


### PR DESCRIPTION
Work around same issue as https://github.com/plone/plone.dexterity/pull/68