### PR TITLE
Revert changing checkout_workflow_policy to ASCIILine

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Revert changing ``IIterateSettings.checkout_workflow_policy`` to ASCIILine.
+  [pbauer]
 
 
 3.3.3 (2017-05-31)

--- a/plone/app/iterate/interfaces.py
+++ b/plone/app/iterate/interfaces.py
@@ -321,9 +321,9 @@ class IIterateSettings(Interface):
         required=False
     )
 
-    checkout_workflow_policy = schema.ASCIILine(
+    checkout_workflow_policy = schema.TextLine(
         title=_(u'Checkout workflow policy'),
         description=u'',
-        default='checkout_workflow_policy',
+        default=u'checkout_workflow_policy',
         required=True
     )


### PR DESCRIPTION
since it breaks migrations and has no benefit. 
See https://github.com/plone/plone.app.iterate/commit/a3c13406a66a262e7411c5de0b517beba9348e03#commitcomment-22650424