### PR TITLE
 Revert changing checkout_workflow_policy to ASCIILine

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
-
+- Revert change ``IIterateSettings.checkout_workflow_policy`` to ASCIILine.
+  See https://github.com/plone/plone.app.iterate/commit/a3c13406
+  [pbauer]
 
 3.3.5 (2017-09-08)
 ------------------
@@ -61,7 +62,7 @@ Bug fixes:
 
 - Change ``IIterateSettings.checkout_workflow_policy`` to ASCIILine,
   as required by ``Products.CMFWorkflowPolicy``.
-
+  [tiberiuichim]
 
 3.3.1 (2017-02-12)
 ------------------

--- a/plone/app/iterate/interfaces.py
+++ b/plone/app/iterate/interfaces.py
@@ -321,7 +321,7 @@ class IIterateSettings(Interface):
         required=False
     )
 
-    checkout_workflow_policy = schema.ASCIILine(
+    checkout_workflow_policy = schema.TextLine(
         title=_(u'Checkout workflow policy'),
         description=u'',
         default='checkout_workflow_policy',

--- a/plone/app/iterate/subscribers/workflow.py
+++ b/plone/app/iterate/subscribers/workflow.py
@@ -47,7 +47,7 @@ def handleCheckout(event):
     settings = registry.forInterface(IIterateSettings)
     if not settings.enable_checkout_workflow:
         return
-    policy_id = settings.checkout_workflow_policy
+    policy_id = str(settings.checkout_workflow_policy)
 
     existing_policy = getattr(
         aq_base(event.working_copy), WorkflowPolicyConfig_id, None)

--- a/plone/app/iterate/subscribers/workflow.py
+++ b/plone/app/iterate/subscribers/workflow.py
@@ -47,7 +47,7 @@ def handleCheckout(event):
     settings = registry.forInterface(IIterateSettings)
     if not settings.enable_checkout_workflow:
         return
-    policy_id = str(settings.checkout_workflow_policy)
+    policy_id = settings.checkout_workflow_policy
 
     existing_policy = getattr(
         aq_base(event.working_copy), WorkflowPolicyConfig_id, None)


### PR DESCRIPTION
This fully reverts: https://github.com/plone/plone.app.iterate/commit/a3c13406a66a262e7411c5de0b517beba9348e03

This is a follow up on https://github.com/plone/plone.app.iterate/pull/47 which only partially reverted that change.

I think the ``str()`` cast should also reverted.

Ideally there should be an upgrade step (re-import the registry schema), otherwise the schema's field type wouldn't be changed from ASCIILine to TextLine for existing installations with that type.

I leave that to others to implement, as I'm not sure how to handle upgrades for optional addons.

/cc @pbauer @esteele  

Also see discussion at: https://github.com/plone/plone.app.iterate/commit/a3c13406a66a262e7411c5de0b517beba9348e03