### PR TITLE
Use the Iterate permissions instead of CMF core permissions

### DIFF
--- a/news/67.bugfix
+++ b/news/67.bugfix
@@ -1,2 +1,3 @@
-Use the Iterate permissions instead of CMF core permissions to support
-customizing the policy. [rpatterson]
+Add support for customizing the policy of checking out and in using Zope's ACL
+security.  Use the Iterate permissions instead of CMF core permissions and
+allow controlling access based on who initiated the check out. [rpatterson]

--- a/news/67.bugfix
+++ b/news/67.bugfix
@@ -1,0 +1,2 @@
+Use the Iterate permissions instead of CMF core permissions to support
+customizing the policy. [rpatterson]

--- a/plone/app/iterate/base.py
+++ b/plone/app/iterate/base.py
@@ -28,7 +28,6 @@ Base Checkin Checkout Policy For Content
 
 from Acquisition import aq_inner
 from Acquisition import aq_parent
-from AccessControl import SpecialUsers
 
 from plone.app.iterate import interfaces
 from plone.app.iterate.event import BeforeCheckoutEvent
@@ -37,10 +36,11 @@ from plone.app.iterate.event import CheckoutEvent
 from plone.app.iterate.interfaces import ICheckinCheckoutPolicy
 from plone.app.iterate.interfaces import IObjectCopier
 from plone.app.iterate.util import get_storage
-from plone import api
+from plone.app.iterate import util
 
 from Products.CMFCore import interfaces as cmf_ifaces
 from Products.CMFCore.utils import getToolByName
+
 from zope import component
 from zope.component import queryAdapter
 from zope.event import notify
@@ -155,7 +155,8 @@ class BaseContentCopier(object):
     def _copyBaseline(self, container):
         # copy the context from source to the target container
         source_container = aq_parent(aq_inner(self.context))
-        with api.env._adopt_user(SpecialUsers.system):
+
+        with util.adopt_system():
             clipboard = source_container.manage_copyObjects(
                 [self.context.getId()])
             result = container.manage_pasteObjects(clipboard)

--- a/plone/app/iterate/base.py
+++ b/plone/app/iterate/base.py
@@ -28,6 +28,7 @@ Base Checkin Checkout Policy For Content
 
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from AccessControl import SecurityManagement
 
 from plone.app.iterate import interfaces
 from plone.app.iterate.event import BeforeCheckoutEvent
@@ -164,4 +165,10 @@ class BaseContentCopier(object):
         # get a reference to the working copy
         target_id = result[0]['new_id']
         target = container._getOb(target_id)
+
+        security_manager = SecurityManagement.getSecurityManager()
+        target.manage_addLocalRoles(
+            security_manager.getUser().getId(),
+            ('iterate: Check out initiator', ))
+
         return target

--- a/plone/app/iterate/base.py
+++ b/plone/app/iterate/base.py
@@ -28,6 +28,8 @@ Base Checkin Checkout Policy For Content
 
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from AccessControl import SpecialUsers
+
 from plone.app.iterate import interfaces
 from plone.app.iterate.event import BeforeCheckoutEvent
 from plone.app.iterate.event import CancelCheckoutEvent
@@ -35,6 +37,8 @@ from plone.app.iterate.event import CheckoutEvent
 from plone.app.iterate.interfaces import ICheckinCheckoutPolicy
 from plone.app.iterate.interfaces import IObjectCopier
 from plone.app.iterate.util import get_storage
+from plone import api
+
 from Products.CMFCore import interfaces as cmf_ifaces
 from Products.CMFCore.utils import getToolByName
 from zope import component
@@ -151,8 +155,10 @@ class BaseContentCopier(object):
     def _copyBaseline(self, container):
         # copy the context from source to the target container
         source_container = aq_parent(aq_inner(self.context))
-        clipboard = source_container.manage_copyObjects([self.context.getId()])
-        result = container.manage_pasteObjects(clipboard)
+        with api.env._adopt_user(SpecialUsers.system):
+            clipboard = source_container.manage_copyObjects(
+                [self.context.getId()])
+            result = container.manage_pasteObjects(clipboard)
 
         # get a reference to the working copy
         target_id = result[0]['new_id']

--- a/plone/app/iterate/browser/configure.zcml
+++ b/plone/app/iterate/browser/configure.zcml
@@ -27,7 +27,7 @@
         name="content-checkin"
         class=".checkin.Checkin"
         template="checkin.pt"
-        permission="cmf.ModifyPortalContent"
+        permission="plone.app.iterate.CheckInContent"
         />
 
     <browser:page

--- a/plone/app/iterate/browser/control.py
+++ b/plone/app/iterate/browser/control.py
@@ -62,7 +62,7 @@ class Control(BrowserView):
         if original is None:
             return False
 
-        can_check_in = checkPermission(permissions.CheckinPermission, original)
+        can_check_in = checkPermission(permissions.CheckinPermission, context)
         if not can_check_in:
             return False
 

--- a/plone/app/iterate/browser/control.py
+++ b/plone/app/iterate/browser/control.py
@@ -29,7 +29,7 @@ from plone.app.iterate.interfaces import IWorkingCopy
 from plone.memoize.view import memoize
 from Products.Five.browser import BrowserView
 
-import Products.CMFCore.permissions
+from .. import permissions
 
 
 class Control(BrowserView):
@@ -62,11 +62,8 @@ class Control(BrowserView):
         if original is None:
             return False
 
-        can_modify = checkPermission(
-            Products.CMFCore.permissions.ModifyPortalContent,
-            original,
-        )
-        if not can_modify:
+        can_check_in = checkPermission(permissions.CheckinPermission, original)
+        if not can_check_in:
             return False
 
         return True
@@ -75,6 +72,7 @@ class Control(BrowserView):
         """Check if a checkout is allowed.
         """
         context = aq_inner(self.context)
+        checkPermission = getSecurityManager().checkPermission
 
         if not interfaces.IIterateAware.providedBy(context):
             return False
@@ -92,6 +90,11 @@ class Control(BrowserView):
 
         # check if its is a checkout
         if policy.getBaseline() is not None:
+            return False
+
+        can_check_out = checkPermission(
+            permissions.CheckoutPermission, context)
+        if not can_check_out:
             return False
 
         return True

--- a/plone/app/iterate/browser/info.py
+++ b/plone/app/iterate/browser/info.py
@@ -5,10 +5,12 @@ $Id: base.py 1808 2007-02-06 11:39:11Z hazmat $
 
 from AccessControl import getSecurityManager
 from DateTime import DateTime
+
 from plone.app.iterate.interfaces import IBaseline
 from plone.app.iterate.interfaces import ICheckinCheckoutPolicy
 from plone.app.iterate.interfaces import keys
-from plone.app.iterate.permissions import CheckoutPermission
+from plone.app.iterate import permissions
+
 from plone.memoize.instance import memoize
 from Products.CMFCore.permissions import ModifyPortalContent
 from Products.CMFCore.utils import getToolByName
@@ -104,7 +106,10 @@ class BaselineInfoViewlet(BaseInfoViewlet):
         working_copy = self.working_copy()
         if working_copy is not None and (
                 sm.checkPermission(ModifyPortalContent, self.context) or
-                sm.checkPermission(CheckoutPermission, self.context) or
+                sm.checkPermission(
+                    permissions.CheckoutPermission, self.context) or
+                sm.checkPermission(
+                    permissions.CheckinPermission, self.context) or
                 sm.checkPermission(ModifyPortalContent, working_copy)):
             return self.index()
         else:
@@ -127,7 +132,10 @@ class CheckoutInfoViewlet(BaseInfoViewlet):
         baseline = self.baseline()
         if baseline is not None and (
                 sm.checkPermission(ModifyPortalContent, self.context) or
-                sm.checkPermission(CheckoutPermission, baseline)):
+                sm.checkPermission(
+                    permissions.CheckoutPermission, baseline) or
+                sm.checkPermission(
+                    permissions.CheckinPermission, baseline)):
             return self.index()
         else:
             return ''

--- a/plone/app/iterate/browser/info.py
+++ b/plone/app/iterate/browser/info.py
@@ -109,7 +109,7 @@ class BaselineInfoViewlet(BaseInfoViewlet):
                 sm.checkPermission(
                     permissions.CheckoutPermission, self.context) or
                 sm.checkPermission(
-                    permissions.CheckinPermission, self.context) or
+                    permissions.CheckinPermission, working_copy) or
                 sm.checkPermission(ModifyPortalContent, working_copy)):
             return self.index()
         else:

--- a/plone/app/iterate/browser/info.py
+++ b/plone/app/iterate/browser/info.py
@@ -92,7 +92,7 @@ class BaseInfoViewlet(BrowserView):
             return {}
 
     def _getReference(self):
-        raise NotImplemented
+        raise NotImplementedError()
 
 
 class BaselineInfoViewlet(BaseInfoViewlet):

--- a/plone/app/iterate/configure.zcml
+++ b/plone/app/iterate/configure.zcml
@@ -8,6 +8,16 @@
   <include package="zope.annotation" />
   <include package="Products.CMFCore" file="permissions.zcml" />
 
+  <permission
+    id="plone.app.iterate.CheckInContent"
+    title="iterate : Check in content"
+    />
+
+  <permission
+    id="plone.app.iterate.CheckOutContent"
+    title="iterate : Check out content"
+    />
+
   <include package=".subscribers"/>
   <include package=".browser"/>
 
@@ -84,16 +94,6 @@
           zope.lifecycleevent.interfaces.IObjectRemovedEvent"
      handler=".event.handleDeletion"
      />
-
-  <permission
-    id="plone.app.iterate.CheckInContent"
-    title="iterate : Check in content"
-    />
-
-  <permission
-    id="plone.app.iterate.CheckOutContent"
-    title="iterate : Check out content"
-    />
 
   <include package=".dexterity" zcml:condition="installed plone.app.relationfield" />
   <include file="at.zcml" zcml:condition="installed Products.Archetypes" />

--- a/plone/app/iterate/copier.py
+++ b/plone/app/iterate/copier.py
@@ -116,7 +116,9 @@ class ContentCopier(BaseContentCopier):
         self.context._v_is_cp = 0
 
         wc_id = self.context.getId()
-        wc_container.manage_delObjects([wc_id])
+        # Bypass AT security check,
+        # checking `iterate : Check in content` should be sufficient
+        wc_container._delObject(wc_id)
 
         # move the working copy back to the baseline container
         working_copy = aq_base(self.context)

--- a/plone/app/iterate/copier.py
+++ b/plone/app/iterate/copier.py
@@ -28,9 +28,13 @@ Archtypes specific copier, dexterity folder has its own!
 from Acquisition import aq_base
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from AccessControl import SpecialUsers
+
 from plone.app.iterate import interfaces
 from plone.app.iterate.base import BaseContentCopier
 from plone.app.iterate.interfaces import CheckinException
+from plone import api
+
 from Products.Archetypes.Referenceable import Referenceable
 from Products.CMFCore.utils import getToolByName
 from Products.DCWorkflow.DCWorkflow import DCWorkflowDefinition
@@ -118,7 +122,8 @@ class ContentCopier(BaseContentCopier):
         wc_id = self.context.getId()
         # Bypass AT security check,
         # checking `iterate : Check in content` should be sufficient
-        wc_container._delObject(wc_id)
+        with api.env._adopt_user(SpecialUsers.system):
+            wc_container.manage_delObjects([wc_id])
 
         # move the working copy back to the baseline container
         working_copy = aq_base(self.context)

--- a/plone/app/iterate/copier.py
+++ b/plone/app/iterate/copier.py
@@ -28,23 +28,23 @@ Archtypes specific copier, dexterity folder has its own!
 from Acquisition import aq_base
 from Acquisition import aq_inner
 from Acquisition import aq_parent
-from AccessControl import SpecialUsers
 
 from plone.app.iterate import interfaces
 from plone.app.iterate.base import BaseContentCopier
 from plone.app.iterate.interfaces import CheckinException
-from plone import api
 
 from Products.Archetypes.Referenceable import Referenceable
 from Products.CMFCore.utils import getToolByName
 from Products.DCWorkflow.DCWorkflow import DCWorkflowDefinition
-from .relation import WorkingCopyRelation
 from ZODB.PersistentMapping import PersistentMapping
 from zope import component
 from zope import interface
 from zope.annotation.interfaces import IAnnotations
 from zope.event import notify
 from zope.lifecycleevent import ObjectMovedEvent
+
+from . import util
+from .relation import WorkingCopyRelation
 
 
 @interface.implementer(interfaces.IObjectCopier)
@@ -122,7 +122,7 @@ class ContentCopier(BaseContentCopier):
         wc_id = self.context.getId()
         # Bypass AT security check,
         # checking `iterate : Check in content` should be sufficient
-        with api.env._adopt_user(SpecialUsers.system):
+        with util.adopt_system():
             wc_container.manage_delObjects([wc_id])
 
         # move the working copy back to the baseline container

--- a/plone/app/iterate/permissions.py
+++ b/plone/app/iterate/permissions.py
@@ -26,6 +26,7 @@ from AccessControl.Permission import addPermission
 CheckinPermission = 'iterate : Check in content'
 CheckoutPermission = 'iterate : Check out content'
 
-DEFAULT_ROLES = ('Manager', 'Owner', 'Site Administrator', 'Editor')
-addPermission(CheckinPermission, default_roles=DEFAULT_ROLES)
-addPermission(CheckoutPermission, default_roles=DEFAULT_ROLES)
+addPermission(CheckinPermission, default_roles=(
+    'Manager', 'Site Administrator', 'Reviewer'))
+addPermission(CheckoutPermission, default_roles=(
+    'Manager', 'Owner', 'Site Administrator', 'Editor'))

--- a/plone/app/iterate/testing.py
+++ b/plone/app/iterate/testing.py
@@ -34,10 +34,16 @@ CONTRIBUTOR = {
     'password': 'secret',
     'roles': ['Contributor'],
 }
+REVIEWER = {
+    'id': 'reviewer',
+    'password': 'secret',
+    'roles': ['Reviewer'],
+}
 USERS_TO_BE_ADDED = (
     ADMIN,
     EDITOR,
     CONTRIBUTOR,
+    REVIEWER,
 )
 USERS_WITH_MEMBER_FOLDER = (
     EDITOR,

--- a/plone/app/iterate/util.py
+++ b/plone/app/iterate/util.py
@@ -21,10 +21,19 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ##################################################################
 
-from .interfaces import annotation_key
+import contextlib
+
 from persistent.dict import PersistentDict
-from Products.CMFPlone.utils import get_installer
+
 from zope.annotation import IAnnotations
+from zope import globalrequest
+
+from AccessControl import SpecialUsers
+from AccessControl import SecurityManagement
+
+from Products.CMFPlone.utils import get_installer
+
+from .interfaces import annotation_key
 
 
 def get_storage(context, default=None):
@@ -40,3 +49,16 @@ def upgrade_by_reinstall(context):
     qi = get_installer(context)
     qi.uninstall_product('plone.app.iterate')
     qi.install_product('plone.app.iterate')
+
+
+@contextlib.contextmanager
+def adopt_system(user=SpecialUsers.system):
+    """
+    Execute this block of code as the system user.
+    """
+    old_security_manager = SecurityManagement.getSecurityManager()
+    SecurityManagement.newSecurityManager(globalrequest.getRequest(), user)
+
+    yield
+
+    SecurityManagement.setSecurityManager(old_security_manager)


### PR DESCRIPTION
Use the Iterate permissions instead of CMF core permissions to support customizing the policy.

Related to #59 and #67