### PR TITLE
Explicitly load zcml of dependencies.

### DIFF
--- a/news/2952.bugfix
+++ b/news/2952.bugfix
@@ -1,0 +1,2 @@
+Explicitly load zcml of dependencies, instead of using ``includeDependencies``.
+[maurits]

--- a/plone/app/iterate/configure.zcml
+++ b/plone/app/iterate/configure.zcml
@@ -5,13 +5,25 @@
     xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="plone">
 
+  <include package="Products.CMFCore" file="meta.zcml"/>
+  <include package="Products.GenericSetup" file="meta.zcml"/>
+  <include package="zope.component" file="meta.zcml"/>
+  <include package="zope.viewlet" file="meta.zcml"/>
+
+  <include package="plone.locking" />
+  <include package="plone.memoize" />
+  <include package="Products.CMFCore" />
+  <include package="Products.CMFEditions" />
+  <include package="Products.CMFPlacefulWorkflow" />
+  <include package="Products.DCWorkflow" />
+  <include package="Products.GenericSetup" />
+  <include package="Products.statusmessages" />
   <include package="zope.annotation" />
-  <include package="Products.CMFCore" file="permissions.zcml" />
+  <include package="zope.component" />
+  <include package="zope.viewlet" />
 
   <include package=".subscribers"/>
   <include package=".browser"/>
-
-  <includeDependencies package="." />
 
   <genericsetup:registerProfile
     name="default"


### PR DESCRIPTION
This is instead of using includeDependencies.
See https://github.com/plone/Products.CMFPlone/issues/2952