### PR TITLE
Make sure relationship between baseline and wc is removed when wc is removed

### DIFF
--- a/news/77.bugfix
+++ b/news/77.bugfix
@@ -1,0 +1,1 @@
+- Remove relationship between baseline and working copy, when wc is removed

--- a/plone/app/iterate/base.py
+++ b/plone/app/iterate/base.py
@@ -37,6 +37,7 @@ from plone.app.iterate.interfaces import IObjectCopier
 from plone.app.iterate.util import get_storage
 from Products.CMFCore import interfaces as cmf_ifaces
 from Products.CMFCore.utils import getToolByName
+from zc.relation.interfaces import ICatalog
 from zope import component
 from zope.component import queryAdapter
 from zope.event import notify
@@ -83,6 +84,11 @@ class CheckinCheckoutBasePolicyAdapter(object):
 
         # publish an event
         notify(CancelCheckoutEvent(self.context, baseline))
+
+        # Remove the relationship
+        relation = self._get_relation_to_baseline()
+        catalog = component.queryUtility(ICatalog)
+        catalog.unindex(relation)
 
         # delete the working copy
         wc_container = aq_parent(aq_inner(self.context))

--- a/plone/app/iterate/dexterity/copier.py
+++ b/plone/app/iterate/dexterity/copier.py
@@ -113,8 +113,9 @@ class ContentCopier(BaseContentCopier):
     def _deleteWorkingCopyRelation(self):
         # delete the wc reference keeping a reference to it for its annotations
         relation = self._get_relation_to_baseline()
-        relation.broken(relation.to_path)
-        return relation
+        catalog = component.queryUtility(ICatalog)
+        catalog.unindex(relation)
+        return
 
     def _get_relation_to_baseline(self):
         context = aq_inner(self.context)


### PR DESCRIPTION
This is a fix for https://github.com/plone/plone.app.iterate/issues/77