### PR TITLE
Update action icons

### DIFF
--- a/news/60.bugfix
+++ b/news/60.bugfix
@@ -1,0 +1,2 @@
+Use proper action icons in Plone 6.
+[maurits]

--- a/plone/app/iterate/browser/configure.zcml
+++ b/plone/app/iterate/browser/configure.zcml
@@ -67,7 +67,7 @@
         />
 
     <!-- Resources -->
-
+    <!-- These resources are deprecated.  Remove them in Plone 7. -->
     <browser:resource
         name="checkin.png"
         image="checkin.png"

--- a/plone/app/iterate/configure.zcml
+++ b/plone/app/iterate/configure.zcml
@@ -70,15 +70,22 @@
       title="Working Copy Support (Iterate) [uninstall]"
       directory="profiles/uninstall"
       provides="Products.GenericSetup.interfaces.EXTENSION"
+      for="plone.base.interfaces.IMigratingPloneSiteRoot"
       />
 
-  <genericsetup:upgradeStep
-      source="*"
-      destination="121"
-      title="Reinstall plone.app.iterate"
-      description=""
-      profile="plone.app.iterate:plone.app.iterate"
-      handler="plone.app.iterate.util.upgrade_by_reinstall"
+  <genericsetup:registerProfile
+      name="to1000"
+      title="Use new icons"
+      directory="profiles/to1000"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
+  <genericsetup:upgradeDepends
+      source="121"
+      destination="1000"
+      title="Use new icons"
+      profile="plone.app.iterate:default"
+      import_profile="plone.app.iterate:to1000"
       />
 
   <utility

--- a/plone/app/iterate/profiles/default/actions.xml
+++ b/plone/app/iterate/profiles/default/actions.xml
@@ -7,7 +7,7 @@
    <property name="title" i18n:translate="">Check in</property>
    <property name="description" i18n:translate=""></property>
    <property name="url_expr">string:${object_url}/@@content-checkin</property>
-   <property name="icon_expr">string:${portal_url}/++resource++checkout.png</property>
+   <property name="icon_expr">string:box-arrow-in-up-right</property>
    <property name="available_expr">python:path('object/@@iterate_control').checkin_allowed()</property>
    <property name="permissions">
     <element value="View"/>
@@ -19,7 +19,7 @@
    <property name="title" i18n:translate="">Check out</property>
    <property name="description" i18n:translate=""></property>
    <property name="url_expr">string:${object_url}/@@content-checkout</property>
-   <property name="icon_expr">string:${portal_url}/++resource++checkout.png</property>
+   <property name="icon_expr">string:box-arrow-down-left</property>
    <property name="available_expr">python:path('object/@@iterate_control').checkout_allowed()</property>
    <property name="permissions">
     <element value="View"/>
@@ -31,7 +31,7 @@
    <property name="title" i18n:translate="">Cancel check-out</property>
    <property name="description" i18n:translate=""></property>
    <property name="url_expr">string:${object_url}/@@content-cancel-checkout</property>
-   <property name="icon_expr">string:${portal_url}/++resource++cancel-checkout.png</property>
+   <property name="icon_expr">string:arrow-counterclockwise</property>
    <property name="available_expr">python:path('object/@@iterate_control').cancel_allowed()</property>
    <property name="permissions">
     <element value="Modify portal content"/>

--- a/plone/app/iterate/profiles/default/metadata.xml
+++ b/plone/app/iterate/profiles/default/metadata.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <!-- When this version is updated, be sure to update the target version
-       of the 'upgrade_by_reinstall' upgrade step, or (better) add a real
-       upgrade step that only makes necessary changes. -->
-  <version>121</version>
+  <version>1000</version>
 </metadata>

--- a/plone/app/iterate/profiles/to1000/actions.xml
+++ b/plone/app/iterate/profiles/to1000/actions.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<object name="portal_actions" meta_type="Plone Actions Tool"
+   xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <object name="object_buttons" meta_type="CMF Action Category">
+
+  <object name="iterate_checkin" meta_type="CMF Action" i18n:domain="plone">
+   <property name="icon_expr">string:box-arrow-in-up-right</property>
+  </object>
+
+  <object name="iterate_checkout" meta_type="CMF Action" i18n:domain="plone">
+   <property name="icon_expr">string:box-arrow-down-left</property>
+  </object>
+
+  <object name="iterate_checkout_cancel" meta_type="CMF Action" i18n:domain="plone">
+   <property name="icon_expr">string:arrow-counterclockwise</property>
+  </object>
+
+ </object>
+</object>

--- a/plone/app/iterate/util.py
+++ b/plone/app/iterate/util.py
@@ -23,7 +23,6 @@
 
 from .interfaces import annotation_key
 from persistent.dict import PersistentDict
-from plone.base.utils import get_installer
 from zope.annotation import IAnnotations
 
 
@@ -34,9 +33,3 @@ def get_storage(context, default=None):
             return default
         annotations[annotation_key] = PersistentDict()
     return annotations[annotation_key]
-
-
-def upgrade_by_reinstall(context):
-    qi = get_installer(context)
-    qi.uninstall_product("plone.app.iterate")
-    qi.install_product("plone.app.iterate")


### PR DESCRIPTION
These are the old icons, which were not visible in Plone 6 (cancel, check out, check in):
![iterate-old-icons](https://user-images.githubusercontent.com/210587/226621379-0acfd120-ed3f-4ca5-9047-afc3f4311075.png)

The nineties called: they wanted their icons back. ;-)

And these the new:
![Screenshot 2023-03-21 at 14 22 36](https://user-images.githubusercontent.com/210587/226621449-ad81273d-ca28-45f0-ba12-d643e0179129.png)
![Screenshot 2023-03-21 at 14 22 49](https://user-images.githubusercontent.com/210587/226621477-e27dd726-dae3-46dd-98f5-316b2b6571f1.png)

Includes upgrade step/profile and removes no longer needed upgrade step.