### PR TITLE
Hide `to1000` profile

### DIFF
--- a/news/+ignore.bugfix
+++ b/news/+ignore.bugfix
@@ -1,0 +1,2 @@
+Hide the `to1000` from the advanced view to create a new plone Site
+[gforcada]

--- a/plone/app/iterate/setuphandlers.py
+++ b/plone/app/iterate/setuphandlers.py
@@ -14,6 +14,7 @@ class HiddenProfiles:
         return [
             "plone.app.iterate:uninstall",
             "plone.app.iterate:plone.app.iterate",
+            "plone.app.iterate:to1000",
         ]
 
 


### PR DESCRIPTION
Otherwise it is shown when creating a new Plone Classic UI site on the advanced view