### PR TITLE
Remove old GenericSetup profile with id `plone.app.iterate`.

### DIFF
--- a/news/99.breaking
+++ b/news/99.breaking
@@ -1,0 +1,3 @@
+Remove old GenericSetup profile with id `plone.app.iterate`.
+See `issue 99 <https://github.com/plone/plone.app.iterate/issues/99#issuecomment-1484686642>`_.
+[maurits]

--- a/plone/app/iterate/configure.zcml
+++ b/plone/app/iterate/configure.zcml
@@ -57,20 +57,6 @@
       directory="profiles/default"
       />
 
-  <!--
-    The plone.app.iterate:plone.app.iterate profile is deprecated.
-    Remove either in Plone 6.1 or 7.0, I am on the fence here.
-    See https://github.com/plone/plone.app.iterate/issues/99#issuecomment-1484686642
-  -->
-  <genericsetup:registerProfile
-      name="plone.app.iterate"
-      title="Working Copy Support (Iterate)"
-      description="Adds working copy support (aka. in-place staging) to Plone."
-      provides="Products.GenericSetup.interfaces.EXTENSION"
-      directory="profiles/default"
-      post_handler=".setuphandlers.deprecate_profile"
-      />
-
   <genericsetup:registerProfile
       name="test"
       title="plone.app.iterate: Test fixture"

--- a/plone/app/iterate/setuphandlers.py
+++ b/plone/app/iterate/setuphandlers.py
@@ -1,8 +1,6 @@
 from plone.base.interfaces.installable import INonInstallable
 from zope.interface import implementer
 
-import warnings
-
 
 @implementer(INonInstallable)
 class HiddenProfiles:
@@ -13,17 +11,5 @@ class HiddenProfiles:
         """
         return [
             "plone.app.iterate:uninstall",
-            "plone.app.iterate:plone.app.iterate",
             "plone.app.iterate:to1000",
         ]
-
-
-def deprecate_profile(tool):
-    """Deprecation profile plone.app.iterate.
-
-    Deprecation warning for plone.app.iterate:plone.app.iterate profile.
-    """
-    warnings.warn(
-        'The profile with id "plone.app.iterate" was renamed to "default".',
-        DeprecationWarning,
-    )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = "5.0.6.dev0"
+version = "6.0.0.dev0"
 
 long_description = (
     f"{Path('README.rst').read_text()}\n{Path('CHANGES.rst').read_text()}"


### PR DESCRIPTION
See https://github.com/plone/plone.app.iterate/issues/99#issuecomment-1484686642. This is for Plone 6.1 only.
Needs a small fix in plone.app.upgrade for good measure.

I have created branch 5.x before this change, and updated coredev 6.0 to use it.