### PR TITLE
Allows working copy of Plone Site

### DIFF
--- a/news/130.feature
+++ b/news/130.feature
@@ -1,1 +1,1 @@
-Allows working copy of Plone Site. @wesleybl
+Support working copies of the Plone Site. @wesleybl

--- a/news/130.feature
+++ b/news/130.feature
@@ -1,0 +1,1 @@
+Allows working copy of Plone Site. @wesleybl

--- a/news/130.feature.2
+++ b/news/130.feature.2
@@ -1,0 +1,1 @@
+Support working copies of content types that don't have versioning enabled. @davisagli

--- a/plone/app/iterate/base.py
+++ b/plone/app/iterate/base.py
@@ -65,7 +65,12 @@ class CheckinCheckoutBasePolicyAdapter:
 
         # use the object copier to checkout the content to the container
         copier = queryAdapter(self.context, IObjectCopier)
-        working_copy, relation = copier.copyTo(container)
+        # The container for the Portal's working copy is the Portal itself.
+        if self.context.portal_type == "Plone Site":
+            working_copy_container = self.context
+        else:
+            working_copy_container = container
+        working_copy, relation = copier.copyTo(working_copy_container)
 
         # publish the event for any subscribers
         notify(CheckoutEvent(self.context, working_copy, relation))

--- a/plone/app/iterate/browser/control.py
+++ b/plone/app/iterate/browser/control.py
@@ -47,10 +47,6 @@ class Control(BrowserView):
         if not interfaces.IIterateAware.providedBy(context):
             return False
 
-        archiver = interfaces.IObjectArchiver(context)
-        if not archiver.isVersionable():
-            return False
-
         if not IWorkingCopy.providedBy(context):
             return False
 
@@ -83,10 +79,6 @@ class Control(BrowserView):
         context = aq_inner(self.context)
 
         if not interfaces.IIterateAware.providedBy(context):
-            return False
-
-        archiver = interfaces.IObjectArchiver(context)
-        if not archiver.isVersionable():
             return False
 
         policy = ICheckinCheckoutPolicy(context, None)

--- a/plone/app/iterate/containers.py
+++ b/plone/app/iterate/containers.py
@@ -64,11 +64,11 @@ class ParentFolderLocator:
 
     @property
     def available(self):
-        return bool(
-            getSecurityManager().checkPermission(
-                AddPortalContent, aq_parent(aq_inner(self.context))
-            )
-        )
+        obj = aq_inner(self.context)
+        # In Plone Site checkout, the working copy container is the portal itself.
+        if obj.portal_type != "Plone Site":
+            obj = aq_parent(obj)
+        return bool(getSecurityManager().checkPermission(AddPortalContent, obj))
 
     def __call__(self):
         if not self.available:

--- a/plone/app/iterate/dexterity/configure.zcml
+++ b/plone/app/iterate/dexterity/configure.zcml
@@ -29,4 +29,8 @@
     <implements interface="plone.app.iterate.dexterity.interfaces.IDexterityIterateAware" />
   </class>
 
+  <class class="Products.CMFPlone.Portal.PloneSite">
+    <implements interface="plone.app.iterate.dexterity.interfaces.IDexterityIterateAware" />
+  </class>
+
 </configure>

--- a/plone/app/iterate/subscribers/versioning.py
+++ b/plone/app/iterate/subscribers/versioning.py
@@ -24,10 +24,14 @@ from plone.app.iterate import interfaces
 
 def handleBeforeCheckout(event):
     archiver = interfaces.IObjectArchiver(event.object)
+    if not archiver.isVersionable():
+        return
     if archiver.isModified() or not archiver.isVersioned():
         archiver.save("Baseline created")
 
 
 def handleAfterCheckin(event):
     archiver = interfaces.IObjectArchiver(event.object)
+    if not archiver.isVersionable():
+        return
     archiver.save(event.message)

--- a/plone/app/iterate/tests/test_containers.py
+++ b/plone/app/iterate/tests/test_containers.py
@@ -220,7 +220,7 @@ class TestIterations(unittest.TestCase):
 
     def test_container_control_checkout_allowed_with_no_policy(self):
         control = Control(self.portal.docs, self.layer["request"])
-        self.assertFalse(control.checkout_allowed())
+        self.assertTrue(control.checkout_allowed())
 
     def test_container_control_cancel_allowed_with_no_policy(self):
         control = Control(self.portal.docs, self.layer["request"])

--- a/plone/app/iterate/tests/test_containers.py
+++ b/plone/app/iterate/tests/test_containers.py
@@ -219,11 +219,11 @@ class TestIterations(unittest.TestCase):
         self.assertFalse(control.checkin_allowed())
 
     def test_container_control_checkout_allowed_with_no_policy(self):
-        control = Control(self.portal, self.layer["request"])
+        control = Control(self.portal.docs, self.layer["request"])
         self.assertFalse(control.checkout_allowed())
 
     def test_container_control_cancel_allowed_with_no_policy(self):
-        control = Control(self.portal, self.layer["request"])
+        control = Control(self.portal.docs, self.layer["request"])
         self.assertFalse(control.cancel_allowed())
 
     def test_container_control_cancel_on_original_does_not_delete_original(self):

--- a/plone/app/iterate/tests/test_iterate.py
+++ b/plone/app/iterate/tests/test_iterate.py
@@ -127,7 +127,7 @@ class TestIterations(unittest.TestCase):
 
     def test_control_checkout_allowed_with_no_policy(self):
         control = Control(self.portal.docs, self.layer["request"])
-        self.assertFalse(control.checkout_allowed())
+        self.assertTrue(control.checkout_allowed())
 
     def test_control_cancel_allowed_with_no_policy(self):
         control = Control(self.portal.docs, self.layer["request"])

--- a/plone/app/iterate/tests/test_iterate.py
+++ b/plone/app/iterate/tests/test_iterate.py
@@ -126,11 +126,11 @@ class TestIterations(unittest.TestCase):
         self.assertFalse(control.checkin_allowed())
 
     def test_control_checkout_allowed_with_no_policy(self):
-        control = Control(self.portal, self.layer["request"])
+        control = Control(self.portal.docs, self.layer["request"])
         self.assertFalse(control.checkout_allowed())
 
     def test_control_cancel_allowed_with_no_policy(self):
-        control = Control(self.portal, self.layer["request"])
+        control = Control(self.portal.docs, self.layer["request"])
         self.assertFalse(control.cancel_allowed())
 
     def test_control_cancel_on_original_does_not_delete_original(self):


### PR DESCRIPTION
This is part of: https://github.com/plone/volto/issues/5284

The container for the Plone Site working copy is Plone Site itself.

To avoid permission errors, the Plone Site working copy is created as the Document type. But right after the Document is created, its portal_type is changed to "Plone Site", so that the schema of the working copy is the same as the Plone Site schema.

Prevents Plone Site permissions from being changed on checkin.

The working copy of Plone Site is created in Plone Site itself. So at checkout, we should check if the user has permission to add content in Plone Site, instead of its parent.