### PR TITLE
Use Plone 6.1 constraints in tox to avoid circular dependency error in Plone 6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ __pycache__/
 .tox
 .vscode/
 node_modules/
+forest.dot
+forest.json
 
 # venv / buildout related
 bin/

--- a/.meta.toml
+++ b/.meta.toml
@@ -7,3 +7,6 @@ commit-id = "a89af8f2"
 
 [pyproject]
 codespell_ignores = "ore,checkin"
+
+[tox]
+constraints_file = "https://dist.plone.org/release/6.1-dev/constraints.txt"

--- a/.meta.toml
+++ b/.meta.toml
@@ -3,7 +3,7 @@
 # See the inline comments on how to expand/tweak this configuration file
 [meta]
 template = "default"
-commit-id = "a89af8f2"
+commit-id = "792c8799"
 
 [pyproject]
 codespell_ignores = "ore,checkin"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,4 +7,4 @@ recursive-include plone *
 global-exclude *pyc
 
 recursive-exclude news *
-exclude news
+exclude news *.yml

--- a/news/+meta.internal
+++ b/news/+meta.internal
@@ -1,0 +1,2 @@
+Update configuration files.
+[plone devs]

--- a/news/131.internal
+++ b/news/131.internal
@@ -1,0 +1,1 @@
+Use Plone 6.1 constraints in tox to avoid circular dependency error in Plone 6.0. @wesleybl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ Zope = [
   'Products.CMFCore', 'Products.CMFDynamicViewFTI',
 ]
 python-dateutil = ['dateutil']
+pytest-plone = ['pytest', 'zope.pytestlayer', 'plone.testing', 'plone.app.testing']
 
 ##
 # Add extra configuration options in .meta.toml:

--- a/tox.ini
+++ b/tox.ini
@@ -108,7 +108,7 @@ set_env =
 ##
 deps =
     zope.testrunner
-    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    -c https://dist.plone.org/release/6.1-dev/constraints.txt
 
 ##
 # Specify additional deps in .meta.toml:
@@ -151,7 +151,7 @@ set_env =
 deps =
     coverage
     zope.testrunner
-    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    -c https://dist.plone.org/release/6.1-dev/constraints.txt
 
 commands =
     coverage run --branch --source plone.app.iterate {envbindir}/zope-testrunner --quiet --all --test-path={toxinidir} -s plone.app.iterate {posargs}
@@ -169,7 +169,7 @@ deps =
     twine
     build
     towncrier
-    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    -c https://dist.plone.org/release/6.1-dev/constraints.txt
 
 commands =
     # fake version to not have to install the package
@@ -200,7 +200,7 @@ allowlist_externals =
 deps =
     pipdeptree
     pipforester
-    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    -c https://dist.plone.org/release/6.1-dev/constraints.txt
 
 commands =
     # Generate the full dependency tree


### PR DESCRIPTION
See: https://github.com/plone/plone.formwidget.recaptcha/pull/37#discussion_r1790443757