### PR TITLE
Implement working copy creation for LRF type

### DIFF
--- a/news/145.feature
+++ b/news/145.feature
@@ -1,0 +1,1 @@
+Add working copy support for `LFR` type. @wesleybl


### PR DESCRIPTION
LRF can't be created at the portal root. So we need to use `unrestricted_construct_instance`.

This is part of: https://github.com/plone/volto/issues/7229